### PR TITLE
feat: add SwitchPalettePlugin to ExtensionsCollection

### DIFF
--- a/ExtensionsCollection.txt
+++ b/ExtensionsCollection.txt
@@ -1,6 +1,6 @@
 |Source     |https://github.com/YakovL/TiddlyWiki_ExtensionsExplorerPlugin/blob/master/ExtensionsCollection.txt|
 |Description|This is a central collection for ExtensionsExplorerPlugin. It is meant to gather collections of existing extensions, and also to help new authors make their work more explorable.|
-|Version    |0.1.0|
+|Version    |0.1.1|
 Current status is "under construction", meaning that there's a lot of collections and extensions to add. Other things should be considered as well, like quality guidelines, handling forks, etc. Instructions for authors will be published in a separate readme and linked here.
 //{{{
 [

--- a/ExtensionsCollection.txt
+++ b/ExtensionsCollection.txt
@@ -17,6 +17,10 @@ Current status is "under construction", meaning that there's a lot of collection
   {
     "url": "https://github.com/YakovL/TiddlyWiki_Extensions/blob/master/FND/SimpleSearchPlugin.js",
     "description": "Displays search results as a simple list of matching tiddlers"
+  },
+  {
+    "url": "https://github.com/PengjuYan/TiddlyWiki_SwitchPalettePlugin/blob/master/SwitchPalettePlugin.js",
+    "description": "Switches among your color palettes"
   }
 ]
 //}}}


### PR DESCRIPTION
Hi Yakov, this is to add my SwitchPalettePlugin to the extension list of EEP, in response to your [suggestions here](https://groups.google.com/g/tiddlywikiclassic/c/6VFoIOUnJ9w/m/A9TzupWVAAAJ).

1. Tell me if it is better to put it in SingleIndex instead.
2. I'll fix my plugin after I got your instruction about my [question here](https://groups.google.com/g/tiddlywikiclassic/c/6VFoIOUnJ9w/m/6Y10ANezAQAJ).
